### PR TITLE
handle ansi visual bell ignore

### DIFF
--- a/lib/ansi.js
+++ b/lib/ansi.js
@@ -91,8 +91,12 @@ exports.exec = function(term, data) {
 			break;
 		}
 		return 3;
+	case 'g': //Visual Bell
+		return 2;
 	case '=':
+		return 2;
 	case '<':
+		return 2;
 	case '>':
 		return 2;
 	default:


### PR DESCRIPTION
seems the ESC g stands for an ansi code to ignore the visual bell. Now correctly handling/ignoring it.
