### PR TITLE
csi.js set n,m to 0 as defaults , handle correct defaults for CSUU & DECSTBM

### DIFF
--- a/lib/csi.js
+++ b/lib/csi.js
@@ -22,7 +22,11 @@ exports.exec = function(term, data) {
 		// Consume escape character.
 		return 1;
 	}
+  // Find the arguments, sometimes they are left blank so we keep the empty string
 	var n = match.args[0], m = match.args[1];
+  if (n !== '') { n = +n }
+  if (m !== '') { m = +m }
+
 	switch(match.cmd) {
 	case '': // Unfinished sequence.
 		return 0;
@@ -60,10 +64,10 @@ exports.exec = function(term, data) {
 		term.mvTab(n || 1);
 		break;
 	case 'J': // ED / DECSED
-		term.eraseInDisplay(n);
+		term.eraseInDisplay(n || 0);
 		break;
 	case 'K': // EL / DECSEL
-		term.eraseInLine(n);
+		term.eraseInLine(n || 0);
 		break;
 	case 'L': // IL
 		term.insertLines(n || 1);

--- a/test/term_buffer.js
+++ b/test/term_buffer.js
@@ -24,12 +24,12 @@ describe('TermBuffer', function() {
 		expect(t.toString()).to.be("1234567890\nabcdefghi")
 		t.write("j")
 		expect(t.toString()).to.be("1234567890\nabcdefghij")
-	})
+	});
 	it("scrolls", function() {
 		var t = newTermBuffer(10, 10);
 		t.write("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20")
 		expect(t.toString()).to.be("11\n12\n13\n14\n15\n16\n17\n18\n19\n20")
-	})
+	});
 	it("moves cursor up", function() {
 		var t = newTermBuffer();
 		t.write("Test\nTest");
@@ -42,14 +42,14 @@ describe('TermBuffer', function() {
 		t.mvCur(0, -2);
 		t.write("!");
 		expect(t.toString()).to.be("Test!\nTest")
-	})
+	});
 	it("moves cursor down", function() {
 		var t = newTermBuffer();
 		t.write("Test\nTest");
 		t.mvCur(0,1);
 		t.write("!");
 		expect(t.toString()).to.be("Test\nTest\n    !")
-	})
+	});
 	it("moves cursor left", function() {
 		var t = newTermBuffer();
 		t.write("Tesd");
@@ -78,11 +78,21 @@ describe('TermBuffer', function() {
 		t.write("\x0e\x0f");
 		expect(t.toString()).to.be("");
 	});
+	it("should overwrite the previous line when moving the cursor up", function() {
+		var t = newTermBuffer();
+		t.write("ABCDEF\n\x1b[AGHIJKL");
+		expect(t.toString()).to.be("GHIJKL");
+	});
+	it("should set ScrollRegion correctly if no params specified", function() {
+		var t = newTermBuffer(80,13);
+		t.write("ABCDEF\n\x1b[1;r");
+		expect(t.scrollRegion[1]).to.be(13);
+	});
 	it("should clear", function() {
 		var t = newTermBuffer();
 		t.write("ABCDEF\n\nFOO\n\x1bH\x1b[2J");
 		expect(t.toString()).to.be("");
-	})
+	});
 	it("emits a inject event", function(done) {
 		var t = newTermBuffer();
 		t.on('inject', function(char) {


### PR DESCRIPTION
I think there is a structural flaw in csi.js

1) while parsing the arguments, the n and m are set to 0 because they use '+'value.
therefore all escape codes that don't specify all arguments get 0 as default. 
I reverted it to without the '+' in front so the case can check if needs to apply defaults
2) DECSTBM needed term.height if no second param is specified for the scrollregion
3) CSUU set (-n || 1) , for all -n the default it probably -1 , so it should read -(n || 1)

they might be other cases that break now, I'll continue to work on those.
