### PR TITLE
resize test

### DIFF
--- a/lib/term_buffer.js
+++ b/lib/term_buffer.js
@@ -451,8 +451,13 @@ TermBuffer.prototype.insertBlanks = function(n) {
 };
 
 TermBuffer.prototype.resize = function(w, h) {
-  // Remove the buffer part above the size
-	this.buffer.splice(h);
+  if (h < this.height) {
+    // Remove the buffer part above the size
+    this.buffer.splice(h);
+  } else {
+    // Add empty lines
+    this.insertLines((h - this.height),0);
+  }
 	for(var i = 0; i < this.buffer.length; i++) {
     if (this.buffer[i]) {
       this.buffer[i].line.splice(w);
@@ -465,7 +470,7 @@ TermBuffer.prototype.resize = function(w, h) {
 
   // Adapt scrollregion - TODO
   var newScrollRegionX = 0;
-  var newScrollRegionY = h;
+  var newScrollRegionY = h-1;
   this.setScrollRegion(newScrollRegionX,newScrollRegionY);
 
   // If the cursor is outside boundaries, it will be corrected
@@ -483,7 +488,6 @@ TermBuffer.prototype.insertLines = function(n, pos) {
 	var tail = this.buffer.length - this.scrollRegion[1];
 	var args = new Array(n);
 	args.unshift(pos, 0);
-	console.log(args);
 	Array.prototype.splice.apply(this.buffer, args);
 	this.buffer.splice(this.scrollRegion[1], this.buffer.length - this.scrollRegion[1] - tail);
 };

--- a/test/term_buffer.js
+++ b/test/term_buffer.js
@@ -98,12 +98,18 @@ describe('TermBuffer', function() {
 		t.write("ABCDEF\n\nFOO\n\x1bH\x1b[2J");
 		expect(t.toString()).to.be("");
 	});
-	it("resize correctly", function() {
+	it("resize correctly to smaller size", function() {
 		var t = newTermBuffer(80,24);
     t.write("line1\n");
 		t.resize(2,2);
     t.write("ab\n");
 		expect(t.toString()).to.be("ab\n");
+	});
+	it("resize correctly to bigger size", function() {
+		var t = newTermBuffer(80,24);
+    t.write("line1\n");
+		t.resize(80,28);
+		expect(t.toString()).to.be("\n\n\n\nline1");
 	});
 	it("emits a linechange event", function(done) {
 		var t = newTermBuffer();


### PR DESCRIPTION
I think the resize code is flawed.

a) if you have in your termBuffer:

```
line1
line2
line3
```

and your cursor is on line3 then when you resize to (2,2) - it should have line2 & line3. 
Currently it splices the top lines, instead of the bottom lines.

b) I think we also need to adapt the scrollregion when we make the terminal smaller
c) not sure what to do if we resize to a larger size. if the scrollregion has been explicitly set we might want to keep it. if it was the default (max screen), we could increase it.

food for thought.
