### PR TITLE
don' emit esc sequences we ignore

### DIFF
--- a/lib/handler/esc.js
+++ b/lib/handler/esc.js
@@ -78,84 +78,73 @@ module.exports = {
 	// ESC N
 	// Single Shift Select of G2 Character Set (SS2 is 0x8e). This affects next character only
 	'N': function(cmd, chunk) {
-		this.write('\x8e');
 		return 2;
 	},
 
 	// ESC O
 	// Single Shift Select of G3 Character Set (SS3 is 0x8f). This affects next character only
 	'O': function(cmd, chunk) {
-		this.write('\x8f');
 		return 2;
 	},
 
 	// ESC P
 	// Device Control String (DCS is 0x90)
 	'P': function(cmd, chunk) {
-		this.write('\x90');
 		return 2;
 	},
 
 	// ESC Q
 	// Private Use 1 (PU1)
 	'R': function(cmd, chunk) {
-		this.write('\x91');
 		return 2;
 	},
 
 	// ESC R
 	// Private Use 2 (PU2)
 	'R': function(cmd, chunk) {
-		this.write('\x92');
 		return 2;
 	},
 
 	// ESC S
 	// Set Transmit State (STS)
 	'S': function(cmd, chunk) {
-		this.write('\x93');
 		return 2;
 	},
 
 	// ESC T
 	// Cancel Character, ignore previous character (CCH)
 	'T': function(cmd, chunk) {
-		this.write('\x94');
+		//TODO
 		return 2;
 	},
 
 	// ESC U
 	// Message Waiting, turns on an indicator on the terminal (MW)
 	'U': function(cmd, chunk) {
-		this.write('\x95');
 		return 2;
 	},
 
 	// ESC V
 	// Start of Protected Area (SPA)
 	'V': function(cmd, chunk) {
-		this.write('\x96');
 		return 2;
 	},
 
 	// ESC W
 	// End of Protected Area (EPA)
 	'W': function(cmd, chunk) {
-		this.write('\x97');
 		return 2;
 	},
 
 	// ESC X
 	// Reserved
 	'X': function(cmd, chunk) {
-		this.write('\x98');
 		return 2;
 	},
 
 	// ESC Y
 	// Reserved
 	'Y': function(cmd, chunk) {
-		this.write('\x99');
 		return 2;
 	},
 
@@ -163,7 +152,6 @@ module.exports = {
 	// DECID Dec Private identification
 	// The kernel returns the string ESC [ ? 6 c , claiming it is a VT102
 	'Z': function(cmd, chunk) {
-		this.write('\x9a');
 		return 2;
 	},
 
@@ -226,16 +214,16 @@ module.exports = {
 	},
 
 	// ESC \
-	// TODO
+	// 7-bit - File Separator (FS)
+	// 8-bit - String Terminator (VT125 exits graphics) (ST)
 	'\\': function(cmd, chunk) {
-		this.write('\x9c');
 		return 2;
 	},
 
 	// ESC ]
-	// Operating System Command (OSC is 0x9d)
+	// 7-bit - Group Separator (GS)
+	// 8-bit - Operating System Command (OSC is 0x9d)
 	']': function(cmd, chunk) {
-		this.write('\x9d');
 		return 2;
 	},
 
@@ -243,7 +231,6 @@ module.exports = {
 	// Privacy Message (password verification), terminaed by ST 
 	// (PM is 0x9e) (PM)
 	'^': function(cmd, chunk) {
-		this.write('\x9e');
 		return 2;
 	},
 
@@ -251,7 +238,6 @@ module.exports = {
 	// Application Program Command (to word processor), term by ST
 	// (APC is 0x9f) (APC)
 	'_': function(cmd, chunk) {
-		this.write('\x9f');
 		return 2;
 	},
 
@@ -259,7 +245,6 @@ module.exports = {
 	// Select default/utf-8 character set.
 	// @ = default, G = utf-8; 8 (Obsolete)
 	'%': function(cmd, chunk) {
-		this.write('\x9f');
 		return 2;
 	},
 
@@ -331,14 +316,20 @@ module.exports = {
 	},
 
 	// ESC <
-	// The terminal interprets all sequences according to ANSI standards X3.64-1979 and X3.41-1974. 
+	// The terminal interprets all sequences according to ANSI standards X3.64-1979 and X3.41-1974.
 	// The VT52 escape sequences described in this chapter are not recognized.
 	// (DECANM)
-	'<': '=',
-	// ESC > 
+	'<': function(cmd, chunk) {
+		return 2;
+	},
+
+	// ESC >
 	// (set numeric keypad mode?)
 	// Normal Keypad (DECPNM)
-	'>': '=',
+	'>': function(cmd, chunk) {
+		return 2;
+	},
+
 	// ESC =
 	// Application Keypad (DECPAM)
 	// Serial port requested application keyboard


### PR DESCRIPTION
If we render it with the AnsiRenderer it will print the ignored codes. 
Therefore we should just discard the codes we ignore.
