### PR TITLE
Fix copy / paste on OSX

### DIFF
--- a/lib/input/dom.js
+++ b/lib/input/dom.js
@@ -1,8 +1,6 @@
 var myUtil = require('../util');
 var inherits = require('util').inherits;
 
-var isMac = typeof window !== 'undefined' && ~window.navigator.userAgent.indexOf('Mac');
-
 function DomInput(target, buffer, opts) {
 	DomInput.super_.apply(this, arguments);
 
@@ -184,7 +182,7 @@ DomInput.prototype._keydown = function(ev) {
 			else if (keyCode === 221)
 				//^] - group sep
 				key = String.fromCharCode(29);
-		} else if ((!isMac && ev.altKey) || (isMac && ev.metaKey)) {
+		} else if (ev.altKey) {
 			if (keyCode >= 65 && keyCode <= 90)
 				key = '\x1b' + String.fromCharCode(keyCode + 32);
 			else if (keyCode === 192)


### PR DESCRIPTION
Applies the same fix that term.js needs:
https://github.com/chjj/term.js/pull/37/files

Terminals on OSX generally use alt for meta and leaves command alone.

@Gottox