### PR TITLE
Expose input and output

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -192,10 +192,10 @@ Terminal.prototype.parseDcs = function(chunk) {
 * @returns a terminal input which can be used to send data to a pty
 */
 Terminal.prototype.dom = function(element, opts) {
-	var input = new DomInput(element, this.state, opts);
-	var output = new DomOutput(this.state, this, element, opts);
+	this.domInput = new DomInput(element, this.state, opts);
+	this.domOutput = new DomOutput(this.state, this, element, opts);
 
-	return input;
+	return this.domInput;
 };
 
 /**


### PR DESCRIPTION
Currently, the doms are edited during the construction of the DomInput and DomOutput objects with no regard to whether or not they have already been initialized.

For this reason, while working with the library I felt the need to have access to these objects in order to implement reconnection mechanisms. 

This change will allow the unpiping and repiping of the doms directly.