### PR TITLE
Removing bottom lines when resizing

### DIFF
--- a/lib/term_state.js
+++ b/lib/term_state.js
@@ -503,8 +503,22 @@ TermState.prototype.setCursor = function(x, y) {
 * @param {object} size - new size of the terminal
 */
 TermState.prototype.resize = function(size) {
-	var line;
-	this._removeLine(0, Math.max(0, this.rows - size.rows));
+	var c = this.cursor;
+
+	// Total number of lines e need to remove in order to resize the terminal
+	var totalLinesToRemove = Math.max(0, this.rows - size.rows);
+	// Number of blank lines from the cursor to the bottom edge of the window
+	var blankLines = this.rows - c.y - 1;
+	// The number of lines we will remove from the bottom part of the terminal
+	var removeFromBottom = Math.min(totalLinesToRemove, blankLines);
+	// The number of lines we will remove from the top part of the terminal
+	var removeFromTop = totalLinesToRemove - removeFromBottom;
+
+	// Remove bottom lines
+	this._removeLine(this.rows - removeFromBottom, removeFromBottom);
+
+	// Remove top lines
+	this._removeLine(0, removeFromTop);
 
 	this.rows = ~~size.rows;
 	this.columns = ~~size.columns;

--- a/lib/term_state.js
+++ b/lib/term_state.js
@@ -523,8 +523,7 @@ TermState.prototype.resize = function(size) {
 	this.rows = ~~size.rows;
 	this.columns = ~~size.columns;
 
-	for(var i = 0; i < this._buffer.str.length; i++)
-		this.setLine(i, this.getLine(i));
+	this.redraw();
 
 	this.setScrollRegion(0, this.rows-1);
 
@@ -532,6 +531,11 @@ TermState.prototype.resize = function(size) {
 
 	this.setCursor();
 	return this;
+};
+
+TermState.prototype.redraw = function(){
+	for(var i = 0; i < this._buffer.str.length; i++)
+		this.setLine(i, this.getLine(i));
 };
 
 /**


### PR DESCRIPTION
When resizing the terminal, only the top lines are being deleted. This causes unexpected behaviors when the cursor is not at the bottom of the terminal.

For instance, if the cursor is at the top line and the terminal is resized to a smaller number of rows, that line will be removed and the empty lines at the bottom will be needlessly preserved.

These changes fix this behavior, by first removing all line below the cursor and only then, if necessary, removing the lines at the top.

I have also extracted and exposed a utility function for redrawing the terminal which can prove useful for other applications.