### PR TITLE
Implements character sets

### DIFF
--- a/lib/handler/chr.js
+++ b/lib/handler/chr.js
@@ -41,11 +41,15 @@ var chr = {
 	/**
 	* SO
 	*/
-	"\x0e": function() { }, // SO
+	"\x0e": function() { // SO
+		this.state.mapCharset("G1");
+	},
 	/**
 	* SI
 	*/
-	"\x0f": function() { }, // SI
+	"\x0f": function() { // SI
+		this.state.mapCharset("G0");
+	},
 
 	/**
 	* ESCAPE

--- a/lib/handler/esc.js
+++ b/lib/handler/esc.js
@@ -95,6 +95,7 @@ var esc = {
 	* Single Shift Select of G2 Character Set (SS2 is 0x8e). This affects next character only
 	*/
 	"N": function(cmd, chunk) {
+		this.state.mapCharset("G2", true);
 		return 2;
 	},
 
@@ -103,6 +104,7 @@ var esc = {
 	* Single Shift Select of G3 Character Set (SS3 is 0x8f). This affects next character only
 	*/
 	"O": function(cmd, chunk) {
+		this.state.mapCharset("G3", true);
 		return 2;
 	},
 
@@ -212,20 +214,18 @@ var esc = {
 	/**
 	* ESC n<br>
 	* Invoke the G2 Character Set as GL (LS2)
-	* @todo implement
 	*/
 	"n": function(cmd, chunk) {
-		// TODO
+		this.state.mapCharset("G2");
 		return 2;
 	},
 
 	/**
 	* ESC o<br>
 	* Invoke the G3 Character Set as GL (LS3)
-	* @todo implement
 	*/
 	"o": function(cmd, chunk) {
-		// TODO
+		this.state.mapCharset("G3");
 		return 2;
 	},
 
@@ -330,7 +330,10 @@ var esc = {
 	* @ = default, G = utf-8; 8 (Obsolete)
 	*/
 	"%": function(cmd, chunk) {
-		return 2;
+		if(chunk[2] === undefined)
+			return 0;
+		this.state.selectCharset("unicode");
+		return 3;
 	},
 
 	/**
@@ -352,24 +355,25 @@ var esc = {
 	},
 
 	/**
-	* ESC ( ) * + - .<br>
-	* TODO
+	* ESC ( ) * + - . /<br>
 	*/
-	"(": function(cmd, chunk) {
+	"(": "/",
+	")": "/",
+	"*": "/",
+	"+": "/",
+	"-": "/",
+	".": "/",
+	"/": function(cmd, chunk) {
+		var targets = { "(": "G0",
+				")": "G1", "*": "G2", "+": "G3",
+				"-": "G1", ".": "G2", "/": "G3" };
 		if(chunk[2] === undefined)
 			return 0;
-		this.state.setMode("graphic", chunk[2] === "0");
-		return 3;
-	},
-	")": ".",
-	"*": ".",
-	"+": ".",
-	"-": ".",
-	".": function(cmd, chunk) {
-		if(chunk[2] === undefined)
+		if(chunk[2] === "%" && chunk[3] === undefined)
 			return 0;
-		this.state.setMode("graphic", false);
-		return 3;
+		var charset = (chunk[2] === "0") ? "graphics" : "unicode";
+		this.state.selectCharset(charset, targets[chunk[1]]);
+		return (chunk[2] === "%") ? 4 : 3;
 	},
 
 	/**

--- a/lib/term_state.js
+++ b/lib/term_state.js
@@ -193,6 +193,14 @@ TermState.prototype.reset = function() {
 		reverse: false,
 		graphic: false
 	};
+	this._charsets = {
+		"G0": "unicode",
+		"G1": "unicode",
+		"G2": "unicode",
+		"G3": "unicode"
+	};
+	this._mappedCharset = "G0";
+	this._mappedCharsetNext = "G0";
 	this._metas = {
 		title: "",
 		icon: ""
@@ -277,21 +285,45 @@ TermState.prototype._write = function(chunk, encoding, callback) {
 };
 
 /**
-* converts graphics from ascii to utf8 characters when in graphics mode.
+* invokes the specified charset (G0, G1, G2, G3) for use,
+* either permanently or only on the next character
+*/
+TermState.prototype.mapCharset = function(target, nextOnly) {
+	this._mappedCharset = target;
+	if (!nextOnly) this._mappedCharsetNext = target;
+	this._modes.graphic = this._charsets[this._mappedCharset] === "graphics"; // backwards compatibility
+};
+
+/**
+* designates (populates) the specified charset (G0, G1, G2, G3) graphics.
+* only "graphics" and "unicode" supported
+*/
+TermState.prototype.selectCharset = function(charset, target) {
+	if (!target) target = this._mappedCharset;
+	this._charsets[target] = charset;
+	this._modes.graphic = this._charsets[this._mappedCharset] === "graphics"; // backwards compatibility
+};
+
+/**
+* converts graphics from ascii to utf8 characters when the
+* active character set has graphics selected
 * @private
 */
 TermState.prototype._graphConvert = function(content) {
-	var result = "", i;
-	if(this._modes.graphic) {
-		for(i = 0; i < content.length; i++) {
-			result += (content[i] in graphics) ?
-				graphics[content[i]] :
-				content[i];
-		}
-		return result;
-	} else  {
+	// optimization for 99% of the time
+	if(this._mappedCharset === this._mappedCharsetNext && !this._modes.graphic) {
 		return content;
 	}
+
+	var result = "", i;
+	for(i = 0; i < content.length; i++) {
+		result += (this._modes.graphic && content[i] in graphics) ?
+			graphics[content[i]] :
+			content[i];
+		this._mappedCharset = this._mappedCharsetNext;
+		this._modes.graphic = this._charsets[this._mappedCharset] === "graphics"; // backwards compatibility
+	}
+	return result;
 };
 
 /**


### PR DESCRIPTION
Changes:

 - [X] Make `TermState` keep track of each character set (`G0`, `G1`, `G2`, `G3`) independently, and the active one.
 - [X] Implement `SI` and `SO`.
 - [X] Implement `ESC N O n o`.
 - [X] Implement `ESC ( ) * + - .` correctly (also fix parsing in rare cases).
 - [X] Fix parsing of `ESC % C`, which didn't consume the extra character.
 - [X] Parse `ESC / C`, which designates `G3`.

The `this._modes.graphic` attribute is still updated for backwards compatibility.

Without this, some implementations of ncurses behave incorrectly when `$TERM = screen` because they set `G1` to graphics (`\e)0`) and after some time perform a SO to select it (`\x0E`).
Note that the distinction between `GL` / `GR` is not implemented yet.