### PR TITLE
Support double-width character 

### DIFF
--- a/lib/term_state.js
+++ b/lib/term_state.js
@@ -195,7 +195,7 @@ TermState.prototype.reset = function() {
 		mousesgr: false,
 		reverse: false,
 		graphic: false,
-		wcwidth: false
+		stringWidth: "length"
 	};
 	this._charsets = {
 		"G0": "unicode",
@@ -247,7 +247,7 @@ TermState.prototype._createLine = function(line) {
 TermState.prototype._write = function(chunk, encoding, callback) {
 	var i, j, line;
 	var lines = chunk.split("\n");
-	var wcwidth = this._modes.wcwidth;
+	var stringWidth = this._modes.stringWidth;
 	var wrapped = false;
 	var c = this.cursor;
 	var splitWidth;
@@ -256,11 +256,11 @@ TermState.prototype._write = function(chunk, encoding, callback) {
 	for(i = 0; i < lines.length; i++) {
 		wrapped = false;
 		// Handle long lines
-		if(getWidth(wcwidth, lines[i]) > this.columns - c.x) {
+		if(getWidth(stringWidth, lines[i]) > this.columns - c.x) {
 			if(this._modes.wrap) {
-				splitWidth = indexOfWidth(wcwidth, lines[i], this.columns - c.x);
+				splitWidth = indexOfWidth(stringWidth, lines[i], this.columns - c.x);
 				lines.splice(i, 1,
-					substrWidth(wcwidth, lines[i], 0, this.columns - c.x),
+					substrWidth(stringWidth, lines[i], 0, this.columns - c.x),
 					lines[i].substr(splitWidth)
 				);
 				wrapped = true;
@@ -268,9 +268,9 @@ TermState.prototype._write = function(chunk, encoding, callback) {
 			else {
 				lastChar = lines[i].substr(-1);
 				if(c.x >= this.columns)
-					c.x = this.columns - getWidth(wcwidth, lastChar);
-				lines[i] = substrWidth(wcwidth, lines[i], 0,
-					this.columns - c.x - getWidth(wcwidth, lastChar)) +
+					c.x = this.columns - getWidth(stringWidth, lastChar);
+				lines[i] = substrWidth(stringWidth, lines[i], 0,
+					this.columns - c.x - getWidth(stringWidth, lastChar)) +
 					lastChar;
 			}
 		}
@@ -344,24 +344,24 @@ TermState.prototype._graphConvert = function(content) {
 TermState.prototype._lineInject = function(content, wrapped) {
 	var c = this.cursor;
 	var line = this.getLine();
-	var wcwidth = this._modes.wcwidth;
+	var stringWidth = this._modes.stringWidth;
 	var args;
 	var splitSubstr;
 	if(this._modes.insert) {
 		args = new Array(content.length);
 		args.unshift(line.attr, line.str.length+1, c.x, 0);
 		myUtil.objSplice.apply(0, args);
-		line.str = substrWidth(wcwidth, line.str, 0, c.x) +
-			myUtil.repeat(" ", c.x - getWidth(wcwidth, line.str)) +
+		line.str = substrWidth(stringWidth, line.str, 0, c.x) +
+			myUtil.repeat(" ", c.x - getWidth(stringWidth, line.str)) +
 			this._graphConvert(content) +
-			substrWidth(wcwidth, line.str, c.x);
-		line.str = substrWidth(wcwidth, line.str, 0, this.columns);
+			substrWidth(stringWidth, line.str, c.x);
+		line.str = substrWidth(stringWidth, line.str, 0, this.columns);
 	}
 	else {
-		line.str = substrWidth(wcwidth, line.str, 0, c.x) +
-			myUtil.repeat(" ", c.x - getWidth(wcwidth, line.str)) +
+		line.str = substrWidth(stringWidth, line.str, 0, c.x) +
+			myUtil.repeat(" ", c.x - getWidth(stringWidth, line.str)) +
 			this._graphConvert(content) +
-			substrWidth(wcwidth, line.str, c.x + getWidth(wcwidth, content));
+			substrWidth(stringWidth, line.str, c.x + getWidth(stringWidth, content));
 	}
 
 	this._applyAttributes(line, c.x, content.length);
@@ -369,7 +369,7 @@ TermState.prototype._lineInject = function(content, wrapped) {
 		line.attr.wrapped = true;
 	this.setLine(c.y, line);
 
-	c.x += getWidth(wcwidth, content);
+	c.x += getWidth(stringWidth, content);
 };
 
 /**

--- a/lib/term_state.js
+++ b/lib/term_state.js
@@ -2,6 +2,9 @@
 
 var myUtil = require("./util.js");
 var inherits = require("util").inherits;
+var getWidth = myUtil.getWidth;
+var indexOfWidth = myUtil.indexOfWidth;
+var substrWidth = myUtil.substrWidth;
 
 /**
 * map of graphical character aliases
@@ -191,7 +194,8 @@ TermState.prototype.reset = function() {
 		mousemtn: false,
 		mousesgr: false,
 		reverse: false,
-		graphic: false
+		graphic: false,
+		wcwidth: false
 	};
 	this._charsets = {
 		"G0": "unicode",
@@ -243,25 +247,34 @@ TermState.prototype._createLine = function(line) {
 TermState.prototype._write = function(chunk, encoding, callback) {
 	var i, j, line;
 	var lines = chunk.split("\n");
+	var wcwidth = this._modes.wcwidth;
 	var wrapped = false;
 	var c = this.cursor;
+	var splitWidth;
 
 	for(i = 0; i < lines.length; i++) {
 		wrapped = false;
 		// Handle long lines
-		if(lines[i].length > this.columns - c.x) {
+		if(getWidth(wcwidth, lines[i]) > this.columns - c.x) {
 			if(c.x >= this.columns)
 				c.x = this.columns - 1;
+			splitWidth =
+				indexOfWidth(wcwidth, lines[i], this.columns - c.x);
 			if(this._modes.wrap) {
 				lines.splice(i, 1,
-					lines[i].substr(0, this.columns - c.x),
-					lines[i].substr(this.columns - c.x)
+					lines[i].substr(0, splitWidth),
+					lines[i].substr(splitWidth)
 				);
 				wrapped = true;
 			}
 			else {
-				lines[i] = lines[i].substr(0, this.columns - c.x - 1) +
-					lines[i].substr(-1);
+				if (wcwidth) {
+					lines[i] = lines[i].substr(0, splitWidth);
+				}
+				else {
+					lines[i] = lines[i].substr(0, splitWidth - 1) +
+						lines[i].substr(-1);
+				}
 			}
 		}
 
@@ -334,7 +347,9 @@ TermState.prototype._graphConvert = function(content) {
 TermState.prototype._lineInject = function(content, wrapped) {
 	var c = this.cursor;
 	var line = this.getLine();
+	var wcwidth = this._modes.wcwidth;
 	var args;
+	var splitSubstr;
 	if(this._modes.insert) {
 		args = new Array(content.length);
 		args.unshift(line.attr, line.str.length+1, c.x, 0);
@@ -344,9 +359,10 @@ TermState.prototype._lineInject = function(content, wrapped) {
 		line.str = line.str.substr(0, this.columns);
 	}
 	else {
-		line.str = line.str.substr(0, c.x) +
-			myUtil.repeat(" ", c.x - line.str.length) +
-			this._graphConvert(content) + line.str.substr(c.x + content.length);
+		line.str = substrWidth(wcwidth, line.str, 0, c.x) +
+			myUtil.repeat(" ", c.x - getWidth(wcwidth, line.str)) +
+			this._graphConvert(content) +
+			substrWidth(wcwidth, line.str, c.x + getWidth(wcwidth, content));
 	}
 
 	this._applyAttributes(line, c.x, content.length);
@@ -354,7 +370,7 @@ TermState.prototype._lineInject = function(content, wrapped) {
 		line.attr.wrapped = true;
 	this.setLine(c.y, line);
 
-	c.x += content.length;
+	c.x += getWidth(wcwidth, content);
 };
 
 /**

--- a/lib/term_state.js
+++ b/lib/term_state.js
@@ -351,9 +351,11 @@ TermState.prototype._lineInject = function(content, wrapped) {
 		args = new Array(content.length);
 		args.unshift(line.attr, line.str.length+1, c.x, 0);
 		myUtil.objSplice.apply(0, args);
-		line.str = line.str.substr(0, c.x) + myUtil.repeat(" ",c.x - line.str.length) +
-			this._graphConvert(content) + line.str.substr(c.x);
-		line.str = line.str.substr(0, this.columns);
+		line.str = substrWidth(wcwidth, line.str, 0, c.x) +
+			myUtil.repeat(" ", c.x - getWidth(wcwidth, line.str)) +
+			this._graphConvert(content) +
+			substrWidth(wcwidth, line.str, c.x);
+		line.str = substrWidth(wcwidth, line.str, 0, this.columns);
 	}
 	else {
 		line.str = substrWidth(wcwidth, line.str, 0, c.x) +

--- a/lib/util.js
+++ b/lib/util.js
@@ -43,23 +43,32 @@ exports.indexOf = A.indexOf ?
 /**
 * calculate width of string.
 * @params {string} str - string to calculate
-* @params {boolean} useWcwidth - calculate width by wcwidth or String.length
+* @params {boolean} stringWidth - calculate width by wcwidth or String.length
 */
-function getWidth(useWcwidth, str) {
-	return useWcwidth === true ? wcwidth(str) : str.length;
+function getWidth(stringWidth, str) {
+	if (!stringWidth || !stringWidth.toLowerCase)
+		return str.length;
+	switch (stringWidth.toLowerCase()) {
+		case "wcwidth":
+			return wcwidth(str);
+		case "length":
+			return str.length;
+		default:
+			return str.length;
+	}
 }
 
 /**
 * calculate the position that the prefix of string is a specific width
 * @params {string} str - string to calculate
 * @params {number} width - the width of target string
-* @params {boolean} useWcwidth - calculate width by wcwidth or String.length
+* @params {boolean} stringWidth - calculate width by wcwidth or String.length
 */
-function indexOfWidth(useWcwidth, str, width) {
-	if (useWcwidth !== true)
+function indexOfWidth(stringWidth, str, width) {
+	if (stringWidth === false)
 		return width;
 	for (var i = 0; i <= str.length; i++) {
-		if (getWidth(useWcwidth, str.substr(0, i)) > width)
+		if (getWidth(stringWidth, str.substr(0, i)) > width)
 			return i - 1;
 	}
 	return str.length;
@@ -72,21 +81,21 @@ function indexOfWidth(useWcwidth, str, width) {
 * @params {string} str - string to calculate
 * @params {number} start - the beginning position of string
 * @params {number} width - the width of target string
-* @params {boolean} useWcwidth - calculate width by wcwidth or String.length
+* @params {boolean} stringWidth - calculate width by wcwidth or String.length
 */
-function substrWidth(useWcwidth, str, startWidth, width) {
+function substrWidth(stringWidth, str, startWidth, width) {
 	var length = width;
 	var start = startWidth;
 	var prefixSpace = 0, suffixSpace;
-	if (useWcwidth === true) {
-		start = indexOfWidth(useWcwidth, str, startWidth);
-		if (getWidth(useWcwidth, str.substr(0, start)) < startWidth) {
+	if (stringWidth !== false) {
+		start = indexOfWidth(stringWidth, str, startWidth);
+		if (getWidth(stringWidth, str.substr(0, start)) < startWidth) {
 			start++;
-			prefixSpace = getWidth(useWcwidth, str.substr(0, start)) - startWidth;
+			prefixSpace = getWidth(stringWidth, str.substr(0, start)) - startWidth;
 		}
-		length = indexOfWidth(useWcwidth, str.substr(start), width - prefixSpace);
-		suffixSpace = Math.min(width, getWidth(useWcwidth, str.substr(start))) -
-			(prefixSpace + getWidth(useWcwidth, str.substr(start, length)));
+		length = indexOfWidth(stringWidth, str.substr(start), width - prefixSpace);
+		suffixSpace = Math.min(width, getWidth(stringWidth, str.substr(start))) -
+			(prefixSpace + getWidth(stringWidth, str.substr(start, length)));
 	}
 	return repeat(" ", prefixSpace) + str.substr(start, length) + repeat(" ", suffixSpace);
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var wcwidth = require("wcwidth");
+
 var A = Array.prototype;
 
 exports.extend = function(o){
@@ -36,3 +38,48 @@ exports.indexOf = A.indexOf ?
 		return -1;
 	};
 
+/**
+* calculate width of string.
+* @params {string} str - string to calculate
+* @params {boolean} useWcwidth - calculate width by wcwidth or String.length
+*/
+function getWidth(str, useWcwidth) {
+	return useWcwidth === true ? wcwidth(str) : str.length;
+};
+
+/**
+* calculate the position that the prefix of string is a specific width
+* @params {string} str - string to calculate
+* @params {number} width - the width of target string
+* @params {boolean} useWcwidth - calculate width by wcwidth or String.length
+*/
+function indexOfWidth(str, width, useWcwidth) {
+	if (useWcwidth !== true)
+		return width;
+	for (var i = 0; i <= str.length; i++) {
+		if (getWidth(str.substr(0, i), useWcwidth) > width)
+			return i - 1;
+	}
+	return str.length;
+};
+
+/**
+* extract parts of string, beginning at the character at the specified position,
+* and returns the specified width of characters.
+* @params {string} str - string to calculate
+* @params {number} start - the beginning position of string
+* @params {number} width - the width of target string
+* @params {boolean} useWcwidth - calculate width by wcwidth or String.length
+*/
+function substrWidth(str, start, width, useWcwidth) {
+	var length = width;
+	if (useWcwidth === true) {
+		start = indexOfWidth(str, start, useWcwidth);
+		length = indexOfWidth(str.substr(start), width, useWcwidth);
+	}
+	return str.substr(start, length);
+};
+
+exports.getWidth = getWidth;
+exports.indexOfWidth = indexOfWidth;
+exports.substrWidth = substrWidth;

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,13 +11,15 @@ exports.extend = function(o){
 	return o;
 };
 
-exports.repeat = function(str, n) {
+function repeat(str, n) {
 	var i, result = "";
 	for(i = 0; i < n; i++) {
 		result += str;
 	}
 	return result;
-};
+}
+
+exports.repeat = repeat;
 
 exports.objSplice = function(obj, length, start, end, replace) {
 	var splice = A.splice, args = [ start, end ];
@@ -43,9 +45,9 @@ exports.indexOf = A.indexOf ?
 * @params {string} str - string to calculate
 * @params {boolean} useWcwidth - calculate width by wcwidth or String.length
 */
-function getWidth(str, useWcwidth) {
+function getWidth(useWcwidth, str) {
 	return useWcwidth === true ? wcwidth(str) : str.length;
-};
+}
 
 /**
 * calculate the position that the prefix of string is a specific width
@@ -53,32 +55,41 @@ function getWidth(str, useWcwidth) {
 * @params {number} width - the width of target string
 * @params {boolean} useWcwidth - calculate width by wcwidth or String.length
 */
-function indexOfWidth(str, width, useWcwidth) {
+function indexOfWidth(useWcwidth, str, width) {
 	if (useWcwidth !== true)
 		return width;
 	for (var i = 0; i <= str.length; i++) {
-		if (getWidth(str.substr(0, i), useWcwidth) > width)
+		if (getWidth(useWcwidth, str.substr(0, i)) > width)
 			return i - 1;
 	}
 	return str.length;
-};
+}
 
 /**
 * extract parts of string, beginning at the character at the specified position,
-* and returns the specified width of characters.
+* and returns the specified width of characters. if the character is incomplete,
+* it will be replaced by space.
 * @params {string} str - string to calculate
 * @params {number} start - the beginning position of string
 * @params {number} width - the width of target string
 * @params {boolean} useWcwidth - calculate width by wcwidth or String.length
 */
-function substrWidth(str, start, width, useWcwidth) {
+function substrWidth(useWcwidth, str, startWidth, width) {
 	var length = width;
+	var start = startWidth;
+	var prefixSpace = 0, suffixSpace;
 	if (useWcwidth === true) {
-		start = indexOfWidth(str, start, useWcwidth);
-		length = indexOfWidth(str.substr(start), width, useWcwidth);
+		start = indexOfWidth(useWcwidth, str, startWidth);
+		if (getWidth(useWcwidth, str.substr(0, start)) < startWidth) {
+			start++;
+			prefixSpace = getWidth(useWcwidth, str.substr(0, start)) - startWidth;
+		}
+		length = indexOfWidth(useWcwidth, str.substr(start), width - prefixSpace);
+		suffixSpace = Math.min(width, getWidth(useWcwidth, str.substr(start))) -
+			(prefixSpace + getWidth(useWcwidth, str.substr(start, length)));
 	}
-	return str.substr(start, length);
-};
+	return repeat(" ", prefixSpace) + str.substr(start, length) + repeat(" ", suffixSpace);
+}
 
 exports.getWidth = getWidth;
 exports.indexOfWidth = indexOfWidth;

--- a/lib/util.js
+++ b/lib/util.js
@@ -40,6 +40,12 @@ exports.indexOf = A.indexOf ?
 		return -1;
 	};
 
+function dbcswidth(str) {
+	return str.split("").reduce(function(sum, c) {
+		return sum + (c.charCodeAt(0) > 255 ? 2 : 1);
+	}, 0);
+}
+
 /**
 * calculate width of string.
 * @params {string} str - string to calculate
@@ -51,6 +57,8 @@ function getWidth(stringWidth, str) {
 	switch (stringWidth.toLowerCase()) {
 		case "wcwidth":
 			return wcwidth(str);
+		case "dbcs":
+			return dbcswidth(str);
 		case "length":
 			return str.length;
 		default:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "grunt-mocha-test": "^0.13.2",
     "jsdom": "9.*",
     "jsdom-global": "^2.1.1",
-    "mocha": "^3.3.0"
+    "mocha": "^3.3.0",
+    "wcwidth": "^1.0.1"
   },
   "engine": {
     "node": ">=0.8"

--- a/test/term_state.js
+++ b/test/term_state.js
@@ -339,4 +339,28 @@ describe('TermState', function() {
 		t.write(ch_one);
 		expect(t.toString()).to.be("ab" + ch_one + "efgh" + ch_one);
 	});
+	it("wcwidth mode with insert mode", function() {
+		var t = newTermState(10, 10);
+		var ch_one = "\u4e00"; // "一"; one in chinese
+		t.setMode('wcwidth', true);
+		t.setMode('insert', true);
+		t.write("__");
+		t.setCursor(1,0);
+		t.write(ch_one + ch_one);
+		expect(t.toString()).to.be("_" + ch_one + ch_one + "_");
+  });
+	it("wcwidth mode with insert mode and linebreak", function() {
+		var t = newTermState(10, 10);
+		var ch_one = "\u4e00"; // "一"; one in chinese
+		t.setMode('wcwidth', true);
+		t.setMode('insert', true);
+		t.write("abcdefgh" + ch_one);
+    t.setCursor(6, 0);
+
+		t.write("!");
+		expect(t.toString()).to.be("abcdef!gh ");
+
+		t.write(ch_one + ch_one);
+		expect(t.toString()).to.be("abcdef!" + ch_one + " \n" + ch_one);
+	});
 });

--- a/test/term_state.js
+++ b/test/term_state.js
@@ -324,10 +324,10 @@ describe('TermState', function() {
 		expect(t._buffer.attr[0][5].bold).to.be(true)
 	});
 
-	it("wcwidth mode", function() {
+	it("stringWidth with wcwidth mode", function() {
 		var t = newTermState(10, 10);
 		var ch_one = "\u4e00"; // "一"; one in chinese
-		t.setMode('wcwidth', true);
+		t.setMode('stringWidth', 'wcwidth');
 		t.write("abcdefgh");
 		t.write(ch_one);
 
@@ -339,20 +339,20 @@ describe('TermState', function() {
 		t.write(ch_one);
 		expect(t.toString()).to.be("ab" + ch_one + "efgh" + ch_one);
 	});
-	it("wcwidth mode with insert mode", function() {
+	it("stringWidth with wcwidth mode with insert mode", function() {
 		var t = newTermState(10, 10);
 		var ch_one = "\u4e00"; // "一"; one in chinese
-		t.setMode('wcwidth', true);
+		t.setMode('stringWidth', 'wcwidth');
 		t.setMode('insert', true);
 		t.write("__");
 		t.setCursor(1,0);
 		t.write(ch_one + ch_one);
 		expect(t.toString()).to.be("_" + ch_one + ch_one + "_");
   });
-	it("wcwidth mode with insert mode and linebreak", function() {
+	it("stringWidth with wcwidth mode with insert mode and linebreak", function() {
 		var t = newTermState(10, 10);
 		var ch_one = "\u4e00"; // "一"; one in chinese
-		t.setMode('wcwidth', true);
+		t.setMode('stringWidth', 'wcwidth');
 		t.setMode('insert', true);
 		t.write("abcdefgh" + ch_one);
     t.setCursor(6, 0);

--- a/test/term_state.js
+++ b/test/term_state.js
@@ -311,9 +311,25 @@ describe('TermState', function() {
 		t.setAttribute('bold', true);
 		t.write("def");
 		t.setCursor(1,0);
-		t.insertBlank(2)
+		t.insertBlank(2);
 		expect(t._buffer.str[0]).to.be("a  bcdef");
 		expect(t._buffer.attr[0][0].bold).to.be(false)
 		expect(t._buffer.attr[0][5].bold).to.be(true)
+	});
+
+	it("wcwidth mode", function() {
+		var t = newTermState(10, 10);
+		var ch_one = "\u4e00"; // "一"; one in chinese
+		t.setMode('wcwidth', true);
+		t.write("abcdefgh");
+		t.write(ch_one);
+
+		expect(t.toString()).to.be("abcdefgh" + ch_one);
+		expect(t.cursor.x).to.be(10);
+		expect(t.cursor.y).to.be(0);
+
+		t.setCursor(2,0);
+		t.write(ch_one);
+		expect(t.toString()).to.be("ab" + ch_one + "efgh" + ch_one);
 	});
 });


### PR DESCRIPTION
Fix #119.
- Add mode `stringWidth` to term_state
  - `length`(default): one unit per character
  - `wcwidth`: detect character width by [wcwidth]
  - `dbcs`: detect character width by the definition in [DBCS - Wikipedia]
- Add test cases for `wcwidth`
- Add test cases for `dbcs`

I only make test without any control character.

I'll finish test cases as many as I can.

[wcwidth]: https://github.com/jquast/wcwidth
[DBCS - Wikipedia]: https://en.wikipedia.org/wiki/DBCS
