### PR TITLE
Fix for \x1b[F (move cursor to previous line)

### DIFF
--- a/lib/handler/csi.js
+++ b/lib/handler/csi.js
@@ -62,7 +62,7 @@ var csi = {
 	*/
 	"F": function(cmd, n, m, args, mod) {
 		// (vt52 compatibility mode - Use special graphics character set? )
-		this.state.mvCursor(0, -n || 1).setCursor(0, null);
+		this.state.mvCursor(0, -n || -1).setCursor(0, null);
 	},
 
 	/**


### PR DESCRIPTION
Needs to be -1, not 1